### PR TITLE
Fix null assert crash, add spacing field, and use material button

### DIFF
--- a/tag_view/lib/src/tagview.dart
+++ b/tag_view/lib/src/tagview.dart
@@ -7,14 +7,23 @@ class TagView extends StatefulWidget {
   Color tagBackgroundColor;
   ValueChanged? onDelete;
   ValueChanged? onClick;
+  final double spacing;
 
   int deletePos = -1;
 
-  TagView(this.tags, {this.isEnableDelete = false, this.tagBackgroundColor = Colors.blueAccent, this.onDelete, this.onClick}) {}
+  TagView(
+    this.tags, {
+    super.key,
+    this.isEnableDelete = false,
+    this.tagBackgroundColor = Colors.blueAccent,
+    this.onDelete,
+    this.onClick,
+    this.spacing = 0,
+  }) {}
 
   @override
   State<StatefulWidget> createState() {
-  return _TagView();
+    return _TagView();
   }
 }
 
@@ -22,46 +31,44 @@ class _TagView extends State<TagView> {
   @override
   Widget build(BuildContext context) {
     return Wrap(
+      spacing: widget.spacing,
       children: widget.tags
-          .map((i) =>
-          GestureDetector(
-            onTap: () {
-              widget.onClick!(widget.tags.indexOf(i));
-            },
-            child: Container(
-                margin: EdgeInsets.all(5),
-                padding: const EdgeInsets.only(
-                    top: 5.0, bottom: 5.0, left: 10, right: 5),
-                decoration: BoxDecoration(
-                    color: widget.tagBackgroundColor,
-                    borderRadius: BorderRadius.all(Radius.circular(20))),
-                child: Wrap(
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  children: [
-                    Text(i,
-                        style: TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.bold,
-                            fontSize: 14)),
-                    SizedBox(
-                      width: 2,
+          .map(
+            (i) => MaterialButton(
+              shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(20))),
+              color: widget.tagBackgroundColor,
+              onPressed: () => widget.onClick?.call(widget.tags.indexOf(i)),
+              child: Wrap(
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  Text(
+                    i,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 14,
                     ),
-                    Visibility(
-                      visible: widget.isEnableDelete,
-                      child: InkWell(
-                        onTap: () {
-                          widget.onDelete!(widget.tags.indexOf(i));
-                        },
-                        child: Icon(
-                          Icons.close_outlined,
-                          color: Colors.white,
-                          size: 20,
-                        ),
+                  ),
+                  const SizedBox(
+                    width: 2,
+                  ),
+                  Visibility(
+                    visible: widget.isEnableDelete,
+                    child: InkWell(
+                      onTap: () =>
+                          widget.onDelete?.call(widget.tags.indexOf(i)),
+                      child: const Icon(
+                        Icons.close_outlined,
+                        color: Colors.white,
+                        size: 20,
                       ),
-                    )
-                  ],
-                )),
-          ))
+                    ),
+                  )
+                ],
+              ),
+            ),
+          )
           .toList(),
     );
   }


### PR DESCRIPTION
This PR includes some fixes that were needed in the library:

- There was a null assert that would crash when no callback function was provided. The expected behavior for most libs with optional callback functions is to no-op. This change prevents crashing.
- Added a `spacing` field to dictate the space between tags
- Replaced `GestureDetector` with `MaterialButton` to allow further customization of the tags and also gain mouse-hover detection events.